### PR TITLE
Add PCM registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ fn main() {
     * OAM bug is not yet supported.
 * Sound
     * The most features are functioning.
+    * PCM registers are always emulated for sound tests.
 * Joypad
 * Timer
 * Serial

--- a/core/src/apu/dac.rs
+++ b/core/src/apu/dac.rs
@@ -1,14 +1,16 @@
 #[derive(Debug, Clone)]
 pub struct Dac {
     power: bool,
-    amp: isize,
+    digital_amp: usize,
+    analog_amp: isize,
 }
 
 impl Dac {
     pub fn new() -> Self {
         Self {
             power: false,
-            amp: 0,
+            digital_amp: 0,
+            analog_amp: 0,
         }
     }
 
@@ -19,8 +21,10 @@ impl Dac {
 
         assert!(amp < 16);
 
+        self.digital_amp = amp;
+
         // [0, 15] digital amp is mapped to [-8, 8]
-        self.amp = match amp {
+        self.analog_amp = match amp {
             0..=7 => amp as isize - 8,
             8..=15 => amp as isize - 7,
             _ => unreachable!(),
@@ -28,7 +32,11 @@ impl Dac {
     }
 
     pub fn amp(&self) -> isize {
-        self.amp
+        self.analog_amp
+    }
+
+    pub fn pcm(&self) -> usize {
+        self.digital_amp
     }
 
     pub fn on(&self) -> bool {
@@ -41,6 +49,6 @@ impl Dac {
 
     pub fn power_off(&mut self) {
         self.power = false;
-        self.amp = 0;
+        self.analog_amp = 0;
     }
 }

--- a/core/src/apu/mod.rs
+++ b/core/src/apu/mod.rs
@@ -38,6 +38,14 @@ struct Nr52 {
     power_on: bool,
 }
 
+#[bitfield(u8)]
+struct Pcm {
+    #[bits(4)]
+    low: usize,
+    #[bits(4)]
+    high: usize,
+}
+
 impl Apu {
     pub fn new(hw: HardwareHandle) -> Self {
         let mixer = Mixer::new();
@@ -282,6 +290,24 @@ impl Apu {
 
             self.sync_all();
         }
+    }
+
+    /// Read PCM12 register
+    pub fn read_pcm12(&self) -> u8 {
+        let pcm = Pcm::default()
+            .with_low(self.tones[0].pcm())
+            .with_high(self.tones[1].pcm());
+
+        pcm.into_bits()
+    }
+
+    /// Read PCM34 register
+    pub fn read_pcm34(&self) -> u8 {
+        let pcm = Pcm::default()
+            .with_low(self.wave.pcm())
+            .with_high(self.noise.pcm());
+
+        pcm.into_bits()
     }
 
     fn sync_all(&mut self) {

--- a/core/src/apu/noise.rs
+++ b/core/src/apu/noise.rs
@@ -224,6 +224,10 @@ impl Noise {
     pub fn amp(&self) -> isize {
         self.dac.amp()
     }
+
+    pub fn pcm(&self) -> usize {
+        self.dac.pcm()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/core/src/apu/tone.rs
+++ b/core/src/apu/tone.rs
@@ -309,4 +309,8 @@ impl Tone {
     pub fn amp(&self) -> isize {
         self.dac.amp()
     }
+
+    pub fn pcm(&self) -> usize {
+        self.dac.pcm()
+    }
 }

--- a/core/src/apu/wave.rs
+++ b/core/src/apu/wave.rs
@@ -374,4 +374,8 @@ impl Wave {
     pub fn amp(&self) -> isize {
         self.dac.amp()
     }
+
+    pub fn pcm(&self) -> usize {
+        self.dac.pcm()
+    }
 }

--- a/core/src/mmu.rs
+++ b/core/src/mmu.rs
@@ -113,6 +113,8 @@ impl Mmu {
             0xff6a => todo!("cgb bg palette data"),
             0xff6b => self.gpu.read_obj_color_palette(),
             0xff70 => self.wram.get_bank(),
+            0xff76 => self.apu.read_pcm12(),
+            0xff77 => self.apu.read_pcm34(),
             0x0000..=0xfeff | 0xff80..=0xffff => unreachable!("read non-i/o addr={:04x}", addr),
             _ => {
                 warn!("read unknown i/o addr={:04x}", addr);


### PR DESCRIPTION
* Add PCM registers useful for debugging sound output.
* In read hardware, this is supported since CGB.